### PR TITLE
CLI fix to avoid overflow with carriage return on execution

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -56,7 +56,7 @@ const executeActions = async (
     const args = getFunctionArgs(action);
     const taskTitle =
       args.answer || args.command || (args.url ? `Browsing: ${args.url}` : '');
-    logger.start(`${taskTitle} ${getActionPostfix(action)}`);
+    logger.start(`${taskTitle}\n  ${getActionPostfix(action)}`);
 
     const toolOutput = await agentManager.executeAction(action, args);
     Logger.debug('Tool output:', toolOutput);

--- a/src/helpers/streams.ts
+++ b/src/helpers/streams.ts
@@ -74,11 +74,11 @@ export function getActionPostfix(action: FunctionAction): string {
 
   switch (functionName) {
     case 'read_file':
-      return toItalic(`(Reading file: ${path.basename(args.path)})`);
+      return toItalic(`└ (Reading file: ${path.basename(args.path)})`);
     case 'write_file':
-      return toItalic(`(Writing to file: ${path.basename(args.path)})`);
+      return toItalic(`└ (Writing to file: ${path.basename(args.path)})`);
     case 'update_file':
-      return toItalic(`(Updating file: ${path.basename(args.path)})`);
+      return toItalic(`└ (Updating file: ${path.basename(args.path)})`);
     case 'run_shell':
       // avoid displaying the full cd command.
       const formatted =
@@ -87,9 +87,9 @@ export function getActionPostfix(action: FunctionAction): string {
               .split('&&')
               .slice(args.command.indexOf('&&') + 1)
           : args.command;
-      return toItalic(`(Executing command: ${formatted})`);
+      return toItalic(`└ (Executing command: ${formatted})`);
     case 'browse_url':
-      return toItalic(`(Browsing URL: ${args.url})`);
+      return toItalic(`└ (Browsing URL: ${args.url})`);
     default:
       return '';
   }


### PR DESCRIPTION
Fixing the repetitive display issue by adding a carriage return
![image](https://github.com/user-attachments/assets/0098655d-ced7-48f2-b461-c7dba8b39400)
