### PR TITLE
fix: add a trim() call to remove any extra newline char when calling …

### DIFF
--- a/src/helpers/streams.ts
+++ b/src/helpers/streams.ts
@@ -98,7 +98,7 @@ export function getSubActionMessage(
   action: FunctionAction
 ): string {
   // @todo maybe reactivate after tests
-  let actionMsg = `${message}\n   `;
+  let actionMsg = `${message}\n${chalk.gray('│')}  `;
   const functionName = getFunctionName(action);
   const args = getFunctionArgs(action);
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -116,7 +116,7 @@ export default class Logger {
       this.spin.message(marked.parse(message || '') as string);
       return;
     }
-    this.spin.stop(marked.parse(message || '') as string, code);
+    this.spin.stop((marked.parse(message || '') as string).trim(), code);
     this.#spinnerStarted = false;
   }
 


### PR DESCRIPTION
### Feat: 
- Added a trim() call to remove any extra newline char when calling logger.stop(). 
- added a box-drawing character for a cleaner look

This solves the problem that there would be too many newlines chars in general between every message. 

Now the content looks more compact and cleaner

![Screenshot 2024-11-06 at 16 54 28](https://github.com/user-attachments/assets/2ef3076f-4ce0-49cc-97c7-ce90b056424a)
