### PR TITLE
Hotfix/workspace sync

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -88,6 +88,8 @@ const synchronizeWorkspace = async (
   force: boolean = false
 ): Promise<boolean> => {
   const workspaceDiff = await getWorkspaceChanges(workspace);
+  if (workspaceDiff.isEmpty) return false;
+
   if (workspaceDiff.hasChanges || force) {
     logger.start('Synchronizing workspace');
 

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -103,6 +103,7 @@ const synchronizeWorkspace = async (
     }
 
     await indexFiles(agentId, files);
+    await new Promise((resolve) => setTimeout(resolve, 2000));
     logger.stop('Workspace synchronized');
     return true;
   }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -47,12 +47,12 @@ const initializeAgentConfig = async (
   if (!eligible && !skipWarmup) {
     await initCommand({ workspace });
     eligible = getEligibleAgent(workspace);
-  }
-  if (!eligible) {
-    return null;
+
+    if (eligible) {
+      await synchronizeWorkspace(eligible?.id, workspace, true);
+    }
   }
 
-  await synchronizeWorkspace(eligible?.id, workspace, true);
   return eligible;
 };
 

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -37,6 +37,8 @@ import { isLooping } from '../utils/loopDetection';
 
 marked.use(markedTerminal() as MarkedExtension);
 
+const logger = new Logger();
+
 const initializeAgentConfig = async (
   workspace: string,
   skipWarmup: boolean
@@ -49,6 +51,8 @@ const initializeAgentConfig = async (
   if (!eligible) {
     return null;
   }
+
+  await synchronizeWorkspace(eligible?.id, workspace, true);
   return eligible;
 };
 
@@ -78,7 +82,32 @@ const executeActions = async (
   return results;
 };
 
-const logger = new Logger();
+const synchronizeWorkspace = async (
+  agentId: string,
+  workspace: string,
+  force: boolean = false
+): Promise<boolean> => {
+  const workspaceDiff = await getWorkspaceChanges(workspace);
+  if (workspaceDiff.hasChanges || force) {
+    logger.start('Synchronizing workspace');
+
+    Logger.debug('Agent : Workspace has changes, synchronizing...');
+    await updateWorkspaceState(workspace);
+    // TODO: improve and send only changed files ?
+    const files = await generatePDFs(workspace);
+
+    if (process.env.NODE_ENV !== 'dev') {
+      // Don't pollute the filesystem with temporary files
+      fs.unlinkSync(files[0].path);
+      Logger.debug('Agent : Workspace PDF deleted:', files[0].path);
+    }
+
+    await indexFiles(agentId, files);
+    logger.stop('Workspace synchronized');
+    return true;
+  }
+  return false;
+};
 
 export const queryCommand = async (
   query: string,
@@ -112,29 +141,6 @@ export const queryCommand = async (
       capabilities: agentConfig.capabilities,
       workspace,
     });
-
-    const synchronizeWorkspace = async (): Promise<boolean> => {
-      const workspaceDiff = await getWorkspaceChanges(workspace);
-      if (workspaceDiff.hasChanges) {
-        logger.start('Synchronizing workspace');
-
-        Logger.debug('Agent : Workspace has changes, synchronizing...');
-        await updateWorkspaceState(workspace);
-        // TODO: improve and send only changed files ?
-        const files = await generatePDFs(workspace);
-
-        if (process.env.NODE_ENV !== 'dev') {
-          // Don't pollute the filesystem with temporary files
-          fs.unlinkSync(files[0].path);
-          Logger.debug('Agent : Workspace PDF deleted:', files[0].path);
-        }
-
-        await indexFiles(agentConfig.id, files);
-        logger.stop('Workspace synchronized');
-        return true;
-      }
-      return false;
-    };
 
     const cancelPrevious = async (): Promise<void> => {
       const statusResponse = await getAgentStatus(agentManager.id);
@@ -206,7 +212,7 @@ export const queryCommand = async (
     let workspaceChanged = false;
 
     if (!skipWarmup) {
-      workspaceChanged = await synchronizeWorkspace();
+      workspaceChanged = await synchronizeWorkspace(agentConfig.id, workspace);
     }
     if (agentManager.capabilities.includes('async')) {
       await cancelPrevious();

--- a/src/helpers/workspace.ts
+++ b/src/helpers/workspace.ts
@@ -126,5 +126,11 @@ export function getWorkspaceDiff(
   const hasChanges =
     added.length > 0 || removed.length > 0 || modified.length > 0;
 
-  return { added, removed, modified, hasChanges };
+  return {
+    added,
+    removed,
+    modified,
+    hasChanges,
+    isEmpty: !newState.file_hashes.size,
+  };
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,6 +29,7 @@ export interface WorkspaceDiff {
   removed: string[];
   modified: string[];
   hasChanges: boolean;
+  isEmpty: boolean;
 }
 
 export type StreamEventStatus =


### PR DESCRIPTION
**Anomaly / Improvement**
The workspace sync was deactivated on Agent init, causing the model to be blind on 1st query. 

**Fix**
Force the workspace sync when init the agent before the first query

**Tested**
Tested on Qwen local on a few requests