### PR TITLE
fix: fixed the security stop msg not appearing

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -82,11 +82,10 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
 // This function will be called when the `init` command is executed
 export async function initCommand(options?: InitCommandOptions) {
   try {
-    // Required for the next stop messages to appear correctly
-    const configKey = options?.config || 'CODING_AGENT';
     const workspace = await getWorkspacePath(options);
-    logger.start('Creating agent');
 
+    logger.start('Creating agent');
+    const configKey = options?.config || 'CODING_AGENT';
     const configuration = await getConfiguration(configKey);
     const config = readConfig();
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -49,7 +49,7 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
   if (options?.workspace === false) {
     const path = `/tmp/2501/${Date.now()}`;
     fs.mkdirSync(path, { recursive: true });
-    logger.message(`Using workspace at ${path}`);
+    logger.log(`Using workspace at ${path}`);
     return path;
   }
 
@@ -61,7 +61,7 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
   }
 
   if (!options?.ignoreUnsafe && isDirUnsafe(finalPath)) {
-    logger.stop(
+    logger.log(
       `Files in the workspace "${finalPath}" are considered sensitive`
     );
     const res = await logger.prompt(
@@ -74,9 +74,7 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
       process.exit(0);
     }
 
-    logger.start(`Using workspace at ${finalPath}`);
-  } else {
-    logger.message(`Using workspace at ${finalPath}`);
+    logger.log(`Using workspace at ${finalPath}`);
   }
   return finalPath;
 }
@@ -85,10 +83,9 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
 export async function initCommand(options?: InitCommandOptions) {
   try {
     // Required for the next stop messages to appear correctly
-    logger.start('Initializing');
     const configKey = options?.config || 'CODING_AGENT';
     const workspace = await getWorkspacePath(options);
-    logger.message('Creating agent');
+    logger.start('Creating agent');
 
     const configuration = await getConfiguration(configKey);
     const config = readConfig();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -65,12 +65,15 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
       `Files in the workspace "${finalPath}" are considered sensitive`
     );
     const res = await logger.prompt(
-      `Are you sure you want to proceed with synchronization? This will synchronize a sensitive directory and may overwrite or modify critical files. (y/n)`
+      `Are you sure you want to proceed with synchronization ? This will synchronize a sensitive directory and may overwrite or modify critical files. (y/n)`
     );
-    if (res === false) {
+
+    // The symbol handles the CTRL+C cancelation from user.
+    if (res === false || res.toString() === 'Symbol(clack:cancel)') {
       logger.cancel('Operation cancelled');
       process.exit(0);
     }
+
     logger.start(`Using workspace at ${finalPath}`);
   } else {
     logger.message(`Using workspace at ${finalPath}`);
@@ -81,11 +84,13 @@ async function getWorkspacePath(options?: InitCommandOptions): Promise<string> {
 // This function will be called when the `init` command is executed
 export async function initCommand(options?: InitCommandOptions) {
   try {
+    // Required for the next stop messages to appear correctly
+    logger.start('Initializing');
     const configKey = options?.config || 'CODING_AGENT';
-    const configuration = await getConfiguration(configKey);
     const workspace = await getWorkspacePath(options);
+    const configuration = await getConfiguration(configKey);
 
-    logger.start('Creating agent');
+    logger.message('Creating agent');
     const config = readConfig();
 
     const createResponse = await createAgent(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -88,9 +88,9 @@ export async function initCommand(options?: InitCommandOptions) {
     logger.start('Initializing');
     const configKey = options?.config || 'CODING_AGENT';
     const workspace = await getWorkspacePath(options);
-    const configuration = await getConfiguration(configKey);
-
     logger.message('Creating agent');
+
+    const configuration = await getConfiguration(configKey);
     const config = readConfig();
 
     const createResponse = await createAgent(


### PR DESCRIPTION
## What is this PR
Fixes the informal security msg that wasnt appearing (regression fix)

### What changed
- add the missing logger.start call to make the next messages appear correctly.
- minor: added a space in msg description for readability
- minor: made sure the script stops when ctrl+c is pressed
- minor: called getWorkspacePath before getConfiguration, so that the security msg appears faster (has no impact whatsoever)

### Results
When canceling (dont mind the newline char, it was a test): 
![Screenshot 2024-11-27 at 12 20 21](https://github.com/user-attachments/assets/678c9a06-0c29-47d9-bcd8-7d2f7a38dff0)

When accepting
![Screenshot 2024-11-27 at 14 48 42](https://github.com/user-attachments/assets/811c47ba-b420-46b8-a0fc-1e090767479a)
