### PR TITLE
fix: moved the /usr that usually contains user programs and binaries …

### DIFF
--- a/src/helpers/security.ts
+++ b/src/helpers/security.ts
@@ -29,6 +29,7 @@ const LINUX_ALLOWED_SUBS = [
   '/var/spool/', // Spooling data
   '/var/run/', // Runtime data
   '/var/mail/', // Mail storage
+  '/usr', // User programs and binaries
 
   '/mnt/', // Mounted external storage
   '/media/', // Removable media
@@ -50,7 +51,6 @@ export const UNIX_UNSAFE_DIRS = [
   '/snap',
   '/sys',
   '/tmp',
-  '/usr',
   '/var',
   '/System/',
   '/Applications/',


### PR DESCRIPTION
## What this PR does

Moved the /usr that usually contains user programs and binaries, to allowed sub-directories.
To allow running the CLI in its sub-directories. Ex: '/usr/my-app'

### What it fixes

There is a bug:  We cant init the CLI under '/usr/my-app' for ex. 
It should be allowed since its a valid directory to run user software.