### PR TITLE
bug/ISS-185

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -47,11 +47,11 @@ const initializeAgentConfig = async (
   if (!eligible && !skipWarmup) {
     await initCommand({ workspace });
     eligible = getEligibleAgent(workspace);
+  }
 
-    // If we have an eligible agent, always sync after init
-    if (eligible && !skipWarmup) {
-      await synchronizeWorkspace(eligible?.id, workspace, true);
-    }
+  // Ensure workspace is always synchronized after initialization
+  if (eligible && !skipWarmup) {
+    await synchronizeWorkspace(eligible.id, workspace, true);
   }
 
   return eligible;

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -48,7 +48,8 @@ const initializeAgentConfig = async (
     await initCommand({ workspace });
     eligible = getEligibleAgent(workspace);
 
-    if (eligible) {
+    // If we have an eligible agent, always sync after init
+    if (eligible && !skipWarmup) {
       await synchronizeWorkspace(eligible?.id, workspace, true);
     }
   }


### PR DESCRIPTION
### Pull Request Description

**Title:** Fix Workspace Synchronization After Agent Initialization

**Description:**

This pull request addresses an issue where the workspace was not being synchronized during the first query after initializing an agent with the `@2501 init --config "XXX"` command. The problem was due to the workspace synchronization logic being conditionally executed only when an agent was not already eligible.

**Changes:**

- Ensures that the workspace is always synchronized after an agent is initialized, regardless of whether the workspace is temporary or not.

**Impact:**

- Users will now experience consistent workspace synchronization after initializing an agent, improving the reliability of the CLI tool.

**Related Issues:**

- Fixes: [ISS-185](https://linear.app/2501ai/issue/ISS-185/workspace-was-not-syncronized-when-using-a-dedicated-configuration)

-> CODING_AGENT & PENTESTER , config_id
