### PR TITLE
Feature/iss 240 bin packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ typings/
 # Build output
 dist/
 out/
+bin/
+build/

--- a/package.json
+++ b/package.json
@@ -13,9 +13,23 @@
     "unlink": "npm unlink -g @2501-ai/cli",
     "start": "node .",
     "lint": "tsc --noEmit && eslint . --ext .ts,.tsx --fix",
+    "package": "rm -rf build bin dist && tsc && ncc build dist/index.js -o build && pkg package.json --compress GZip",
     "prepare": "husky",
     "test": "jest --silent",
     "dev": "ts-node ./src/index.ts"
+  },
+  "pkg": {
+    "scripts": "build/**/*.js",
+    "assets": [
+      "build/**/*.afm",
+      "build/**/*.icc",
+      "node_modules/**/*",
+      "package.json"
+    ],
+    "targets": [
+      "node18-macos-arm64"
+    ],
+    "outputPath": "bin"
   },
   "keywords": [
     "AI",
@@ -58,9 +72,11 @@
     "@types/turndown": "^5.0.5",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@vercel/ncc": "^0.38.3",
     "eslint": "^8.57.0",
     "husky": "^9.1.5",
     "jest": "^29.7.0",
+    "pkg": "^5.8.1",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test": "jest --silent",
     "dev": "ts-node ./src/index.ts"
   },
+  "engines": {
+    "node": ">=18.16.0"
+  },
   "pkg": {
     "scripts": "build/**/*.js",
     "assets": [
@@ -76,6 +79,7 @@
     "eslint": "^8.57.0",
     "husky": "^9.1.5",
     "jest": "^29.7.0",
+    "ncc": "^0.3.6",
     "pkg": "^5.8.1",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.4",


### PR DESCRIPTION
# 🚀 Pull Request Overview

### What does this PR do? 🤔

This PR adds the capability of building the CLI into a single binary package.

Although it is a first working version, we will need to change the approach since the library used is now deprecated and compiles for Node <= v18.

Also since Node > v18.16 now has the [Single executable Application feature](https://nodejs.org/api/single-executable-applications.html#single-executable-applications), we should use this approach instead @zhuk-aa 
- `This feature allows the distribution of a Node.js application conveniently to a system that does not have Node.js installed`

### Related Issues 📝

- Linked to https://linear.app/2501ai/issue/ISS-240/create-a-binary-that-encapsulates-the-cli-and-nodejs

## 💻 Changes Summary

- ✅ **Change 1**: Added the NPM **package** script to compile the build for MacOS

### ✅ Checklist

- [ ] I have built and run the binary for MacOS Arm64, and verified that the @2501 cli works well.

## 📈 Impact Analysis

- **Limitations**: This first version will not be sustainable in the long run as mentioned previously
