### PR TITLE
feat: fixed auth problem on jobs and removed logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ program
     'Unsubscribe to the API for new jobs on the current workspace'
   )
   .option('--listen', 'Listen for new jobs from the API and execute them')
+  .hook('preAction', authMiddleware)
   .action(jobSubscriptionCommand);
 
 program

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -152,7 +152,6 @@ export function getDirectoryMd5Hash({
   maxDepth = DEFAULT_MAX_DEPTH,
   maxDirSize = DEFAULT_MAX_DIR_SIZE, // 10MB
 }: DirectoryMd5HashOptions) {
-  Logger.debug('Computing MD5 hash for directory:', directoryPath);
   // Initialize ignore manager at root level
   const ignoreManager = IgnoreManager.getInstance();
 

--- a/src/utils/ignore.ts
+++ b/src/utils/ignore.ts
@@ -88,7 +88,6 @@ export class IgnoreManager {
         }
       }
     });
-    Logger.debug('Unique ignore patterns:', uniquePatterns);
   }
 
   /**


### PR DESCRIPTION
# 🚀 Pull Request Overview

### What does this PR do? 🤔

feat: fixed auth problem on jobs and removed logs.

The authMiddleware handles the default apikey config header assignment.
And calling the `queryCommand` when using `@2501 jobs --listen` would not initialise the default headers properly