### PR TITLE
trap SIGINT as previx on every command run + removing timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -84,11 +84,11 @@ export async function run_shell(args: {
   Logger.debug(`    Running shell command: ${args.command}`);
 
   try {
-    const { stderr, stdout } = await execa(args.command, {
+    const cmd = `trap '' SIGINT && ${args.command}`;
+    const { stderr, stdout } = await execa(cmd, {
       shell: args.shell ?? true,
       env: args.env,
       preferLocal: true,
-      timeout: 1000 * 60,
     });
 
     if (stdout) output += stdout;

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -84,11 +84,27 @@ export async function run_shell(args: {
   Logger.debug(`    Running shell command: ${args.command}`);
 
   try {
-    const cmd = `trap '' SIGINT && ${args.command}`;
+    // Wrap command with proper signal handling and cleanup
+    const cmd = `
+      # Set up cleanup trap for multiple signals
+      cleanup() {
+        trap - EXIT SIGINT SIGTERM SIGQUIT
+        # Add any specific cleanup commands here if needed
+        exit 0
+      }
+      
+      # Set up traps
+      trap cleanup EXIT SIGINT SIGTERM SIGQUIT
+      
+      # Execute the actual command
+      ${args.command}
+    `;
+
     const { stderr, stdout } = await execa(cmd, {
       shell: args.shell ?? true,
       env: args.env,
       preferLocal: true,
+      cleanup: true, // execa's own cleanup
     });
 
     if (stdout) output += stdout;


### PR DESCRIPTION
# 🚀 Pull Request Overview

### What does this PR do? 🤔

Attempt on fixing the long-commands instability issues by removing timeout on execa execution and adding a "trap" on the SIGINT at the shell level. 

Cause : (my understanding) some chained commands are well executed on terminal but will be not working well on subprocess (every language) as the subprocess will be sensitive to signals and send them back to parent processes. 

There's no option in Node.js / Python to solve that, it looks like to be "hacked" on the shell level. 

### Related Issues 📝

- Closes #301

## 💻 Changes Summary

- ✅ **Change 1**: Remove timeout to CLI execa 
- ✅ **Change 2**: Add SIGINT prefix trap command 

### ✅ Checklist

- [ ] I have added **tests** that prove my fix or feature works.
- [ ] New and existing **tests** passed locally with my changes.

## 📈 Impact Analysis

This might impact the shell behavior since we "trap" the SIGINT. 
