### PR TITLE
fix: removed duplicate call to write file that could cause issues to sudo update file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2501-ai/cli",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -104,8 +104,6 @@ export async function update_file({
     ${newContent}
     \`\`\``;
 
-    fs.writeFileSync(path, newContent);
-
     return `
     File updated: ${path}
     ${content}`;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Remove duplicate `fs.writeFileSync` call in `update_file` function
• Fix potential issues with sudo file updates


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Remove duplicate file write operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/helpers/actions.ts

• Removed duplicate <code>fs.writeFileSync(path, newContent)</code> call from <br><code>update_file</code> function<br> • Eliminates potential conflicts with sudo file <br>operations


</details>


  </td>
  <td><a href="https://github.com/2501-ai/cli/pull/159/files#diff-fb26b54b499957001c88c5d88f6496f6a184d1cde54a459f32e4e7547cf08903">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>