### PR TITLE
hotfix/increase output content length

### DIFF
--- a/src/managers/agentManager.ts
+++ b/src/managers/agentManager.ts
@@ -149,6 +149,7 @@ export class AgentManager {
         output += `\n\n NOTE: your original content for ${args.path} was corrected with the new version below before running the function: \n\n${args.content}`;
       }
 
+      // TODO: in codex they use 10kb as limit or 250 lines. Maybe we should investigate.
       if (output.length > 50_000) {
         output = `
         ERROR: The output is too large to display to prevent performance issues.

--- a/src/managers/agentManager.ts
+++ b/src/managers/agentManager.ts
@@ -149,7 +149,7 @@ export class AgentManager {
         output += `\n\n NOTE: your original content for ${args.path} was corrected with the new version below before running the function: \n\n${args.content}`;
       }
 
-      if (output.length > 20000) {
+      if (output.length > 50_000) {
         output = `
         ERROR: The output is too large to display to prevent performance issues.
         Use an alternative method to retrieve the relevant information for the user (for example grep, an another command or sample the content first).


### PR DESCRIPTION
- **fix: icnreased the output content length to see if the agents are capable of supporting longer contexts and provide better results isntead of having to search for contents inside the file for ex, which can lead to having half of the job done.**
- **fix: added comment on output length**
