### PR TITLE
Centralize and fix axios defaults

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,15 @@
+# Cursor Rules for 2501 CLI
+
+## Version Management
+When opening a pull request in this CLI repository, always increment the patch version in both `package.json` and `package-lock.json` files.
+
+Example: If current version is `0.2.43`, increment to `0.2.44`.
+
+Files to update:
+- `package.json`: Update the `"version"` field
+- `package-lock.json`: Update both occurrences of the version (root level and in the packages section)
+
+## Code Style
+- Follow existing TypeScript and ESLint conventions
+- All axios API calls should use the centralized configuration from `initAxios()` in `src/helpers/api.ts`
+- Prefer relative API paths (e.g., `/configurations`) over manually constructed URLs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2501-ai/cli",
-      "version": "0.2.42",
+      "version": "0.2.43",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,16 +1,13 @@
 import axios from 'axios';
 import { terminal } from 'terminal-kit';
 
-import { API_HOST, API_VERSION } from '../constants';
 import Logger from '../utils/logger';
 
 export const configCommand = async () => {
   const logger = new Logger();
   try {
     logger.start('Fetching configurations...');
-    const response = await axios.get(
-      `${API_HOST}${API_VERSION}/configurations`
-    );
+    const response = await axios.get('/configurations');
 
     logger.stop('Configurations fetched successfully.');
     logger.outro('Configurations :');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import { terminal } from 'terminal-kit';
 
 // Local imports
-import { API_HOST, API_VERSION } from '../constants';
 import { createAgent } from '../helpers/api';
 import { isDirUnsafe } from '../helpers/security';
 import { resolveWorkspacePath } from '../helpers/workspace';
@@ -21,9 +20,6 @@ import { DISCORD_LINK } from '../utils/messaging';
 import { getTempPath2501 } from '../utils/platform';
 import { getSystemInfo } from '../utils/systemInfo';
 import { Configuration, RemoteExecConfig } from '../utils/types';
-
-axios.defaults.baseURL = `${API_HOST}${API_VERSION}`;
-axios.defaults.timeout = 120 * 1000;
 
 export interface InitCommandOptions {
   name?: string;

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -23,9 +23,10 @@ export const initAxios = async () => {
     throw new Error('API key must be set.');
   }
 
-  axios.defaults.headers.common['Authorization'] = `Bearer ${apiKey}`;
+  // Set all axios defaults in one place
   axios.defaults.baseURL = `${API_HOST}${API_VERSION}`;
   axios.defaults.timeout = FIVE_MINUTES_MILLIS;
+  axios.defaults.headers.common['Authorization'] = `Bearer ${apiKey}`;
 };
 
 export const createAgent = async (


### PR DESCRIPTION
# 🚀 Pull Request Overview

## What does this PR do? 🤔

This PR centralizes all Axios default configuration within the `initAxios` function in `src/helpers/api.ts`. It removes redundant Axios default settings from `src/commands/init.ts`, improving configuration consistency and maintainability. The package version has also been incremented.

---
[Slack Thread](https://2501-ai.slack.com/archives/C09533GH4UU/p1753943895452289?thread_ts=1753943895.452289&cid=C09533GH4UU)

<a href="https://cursor.com/background-agent?bcId=bc-cd77c0bb-73a4-4246-a73f-96a4bbabc464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd77c0bb-73a4-4246-a73f-96a4bbabc464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>