### PR TITLE
Remove Command Blacklist from CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2501-ai/cli",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2501-ai/cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,5 +108,3 @@ export const DEFAULT_ACTIONS_REPONSE: StreamEvent = {
   actions: [],
   usage: null,
 };
-
-export const BLACKLISTED_COMMANDS = ['nano', 'vim', 'vi', 'nvim'];

--- a/src/managers/agentManager.ts
+++ b/src/managers/agentManager.ts
@@ -12,7 +12,6 @@ import {
 
 import Logger from '../utils/logger';
 
-import { BLACKLISTED_COMMANDS } from '../constants';
 import { getFunctionName } from '../utils/actions';
 import {
   AgentConfig,
@@ -28,18 +27,6 @@ export const ACTION_FNS = {
   update_file,
   task_completed,
 } as const;
-
-function isBlacklistedCommand(command: string): boolean {
-  return BLACKLISTED_COMMANDS.some((blocked) => {
-    // Create a regex pattern that matches the blocked word as a standalone command
-    // This checks for word boundaries or command separators around the blocked term
-    const pattern = new RegExp(
-      `(^|\\s|;|\\||&|>|<)${blocked}($|\\s|;|\\||&|>|<)`,
-      'i'
-    );
-    return pattern.test(command);
-  });
-}
 
 export class AgentManager {
   workspace: string;
@@ -62,24 +49,6 @@ export class AgentManager {
         output: `Function '${functionName}' not found. Please verify the function name and try again.`,
         success: false,
       };
-    }
-
-    if (args.command) {
-      if (isBlacklistedCommand(args.command)) {
-        const errorMessage = [
-          `EXECUTION BLOCKED: Content contains blocked command`,
-          'SECURITY VIOLATION:',
-          `Interactive terminal editors (${BLACKLISTED_COMMANDS.join(', ')}) are strictly prohibited in this environment.`,
-          'These commands require direct user interaction and violate the automated execution policy.',
-          'NOTE: All content containing editor commands will be systematically blocked.',
-        ].join('\n');
-
-        return {
-          tool_call_id: action.id,
-          output: errorMessage,
-          success: false,
-        };
-      }
     }
 
     let taskTitle: string = args.answer || args.command || '';


### PR DESCRIPTION
## Summary

This PR removes the command blacklist functionality that previously blocked interactive terminal editors (nano, vim, vi, nvim) from being executed through the CLI.

## Changes Made

- **Removed `BLACKLISTED_COMMANDS` constant** from `src/constants.ts` that contained the list of blocked commands
- **Deleted `isBlacklistedCommand()` function** from `src/managers/agentManager.ts` that performed pattern matching against blocked commands
- **Removed blacklist validation logic** from the `executeAction()` method that was preventing execution of interactive editors